### PR TITLE
Update parse.h to avoid arithmetic on a pointer to void cast (#1096)

### DIFF
--- a/parse.h
+++ b/parse.h
@@ -125,7 +125,7 @@ static inline void *td_var(void *to, const struct fio_option *o,
 	else
 		ret = to;
 
-	return ret + offset;
+	return (void *) ((uintptr_t) ret + offset);
 }
 
 static inline int parse_is_percent(unsigned long long val)


### PR DESCRIPTION
#1096 shows that a compiler complains an `arithmetic on a pointer to void` error when `-Wpointer-arith` is turned on in Makefile. Although there are many violating instances, we only fix the one in `parse.h` because it is shared across many core source code files. This patch fixes the `arithmetic on a pointer to void` issue by casting it to a uintptr_t type first and perform manipulation, and then cast it back to void* type.